### PR TITLE
Make *new work for ClearList

### DIFF
--- a/classes/MarkovSet/ShannonMarkovSet.sc
+++ b/classes/MarkovSet/ShannonMarkovSet.sc
@@ -236,7 +236,7 @@ ShannonFinger : ShannonMarkovSet {
 ClearList : List {
 	var <size = 0;
 	
-	*new{ arg size; ^this.newClear(size); }
+	*new { arg size; ^this.newClear(size); }
 	add { arg item; array = array.put(size, item); size = size + 1 }
 	put { arg i, item;
 		array.put(i, item); 

--- a/classes/MarkovSet/ShannonMarkovSet.sc
+++ b/classes/MarkovSet/ShannonMarkovSet.sc
@@ -236,6 +236,7 @@ ShannonFinger : ShannonMarkovSet {
 ClearList : List {
 	var <size = 0;
 	
+	*new{arg size; ^this.newClear(size); }
 	add { arg item; array = array.put(size, item); size = size + 1 }
 	put { arg i, item;
 		array.put(i, item); 

--- a/classes/MarkovSet/ShannonMarkovSet.sc
+++ b/classes/MarkovSet/ShannonMarkovSet.sc
@@ -236,7 +236,7 @@ ShannonFinger : ShannonMarkovSet {
 ClearList : List {
 	var <size = 0;
 	
-	*new{arg size; ^this.newClear(size); }
+	*new{ arg size; ^this.newClear(size); }
 	add { arg item; array = array.put(size, item); size = size + 1 }
 	put { arg i, item;
 		array.put(i, item); 

--- a/classes/MarkovSet/ShannonMarkovSet.sc
+++ b/classes/MarkovSet/ShannonMarkovSet.sc
@@ -236,7 +236,7 @@ ShannonFinger : ShannonMarkovSet {
 ClearList : List {
 	var <size = 0;
 	
-	*new { arg size; ^this.newClear(size); }
+	*new { arg size; ^this.newClear(size) }
 	add { arg item; array = array.put(size, item); size = size + 1 }
 	put { arg i, item;
 		array.put(i, item); 


### PR DESCRIPTION
I'm writing a method for generating random collections. I found that the ClearList class throws an error when trying to do ClearList.fill.
The ClearList class is not much used AFAIK and is probably more a convenience class to interface to a List? Nevertheless I propose this fix.

IMO All subclasses should support the same interface as its superclass methods, so by delegating *new to *newClear the class works as one would expect.

