### PR TITLE
Quaternion: added conversion to Euler angles

### DIFF
--- a/classes/various/Quaternion.sc
+++ b/classes/various/Quaternion.sc
@@ -121,18 +121,6 @@ Quaternion {
 		var x, ang, val;
 		val = (2 * (a * c - (b * d))).clip(-1.0, 1.0);
 		ang = asin(val);
-		// select which axis is our reference for tumble (used to determine the quadrant)
-		x = ((this.rotate < 0.5pi) and: (this.rotate > -0.5pi)).if({
-			(1 - (2*(d.squared + c.squared)))
-		}, {
-			(1 - (2*(b.squared + c.squared)))
-		});
-		case(
-			{x.isNegative and: ang.isNegative.not},
-			{ang = pi - ang},
-			{x.isNegative and: ang.isNegative},
-			{ang = ang.neg - pi},
-		);
 		^ang
 	}
 

--- a/classes/various/Quaternion.sc
+++ b/classes/various/Quaternion.sc
@@ -113,20 +113,17 @@ Quaternion {
 
 	// roll
 	tilt {
-		^atan2((2 * (a * b + (c * d))), (1 - (2*(b.squared + c.squared))))
+		^atan2((2 * (a * b - (c * d))), (1 - (2*(b.squared + c.squared))))
 	}
 
 	// pitch
 	tumble {
-		var x, ang, val;
-		val = (2 * (a * c - (b * d))).clip(-1.0, 1.0);
-		ang = asin(val);
-		^ang
+		^asin((2 * (a * c + (b * d))).clip(-1.0, 1.0));
 	}
 
 	// yaw
 	rotate {
-		^atan2((2 * (a * d + (c * b))), (1 - (2*(d.squared + c.squared))))
+		^atan2((2 * (a * d - (c * b))), (1 - (2*(d.squared + c.squared))))
 	}
 }
 

--- a/classes/various/Quaternion.sc
+++ b/classes/various/Quaternion.sc
@@ -107,6 +107,39 @@ Quaternion {
 	printOn { arg stream;
 		stream << "Quaternion(" << a << ", " << b << ", " << c << ", " << d << ")";
 	}
+
+	// conversion to euler angles
+	// Math taken from https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Quaternion_to_Euler_Angles_Conversion
+
+	// roll
+	tilt {
+		^atan2((2 * (a * b + (c * d))), (1 - (2*(b.squared + c.squared))))
+	}
+
+	// pitch
+	tumble {
+		var x, ang, val;
+		val = (2 * (a * c - (b * d))).clip(-1.0, 1.0);
+		ang = asin(val);
+		// select which axis is our reference for tumble (used to determine the quadrant)
+		x = ((this.rotate < 0.5pi) and: (this.rotate > -0.5pi)).if({
+			(1 - (2*(d.squared + c.squared)))
+		}, {
+			(1 - (2*(b.squared + c.squared)))
+		});
+		case(
+			{x.isNegative and: ang.isNegative.not},
+			{ang = pi - ang},
+			{x.isNegative and: ang.isNegative},
+			{ang = ang.neg - pi},
+		);
+		^ang
+	}
+
+	// yaw
+	rotate {
+		^atan2((2 * (a * d + (c * b))), (1 - (2*(d.squared + c.squared))))
+	}
 }
 
 + SimpleNumber {


### PR DESCRIPTION
From the math found [here](https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Quaternion_to_Euler_Angles_Conversion), added Quaternion to Euler angle conversions. The `tumble` method is slightly hacky in two ways. One it clips the value to -1 to 1 to avoid `nan`s and second it attempts to do `atan2` to asin, where we can tell which quadrant we are in so we can know if we go above 0.5pi and below -0.5pi...