### PR TITLE
Quaternion: Euler angles math fix and documentation

### DIFF
--- a/HelpSource/Classes/Quaternion.schelp
+++ b/HelpSource/Classes/Quaternion.schelp
@@ -73,16 +73,28 @@ METHOD:: distance
 Return the distance between two quaternions.
 
 
-METHOD:: rotate
-Return the rotation (yaw) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
+METHOD:: yaw
+Return the yaw (rotation about the z-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
 
 
-METHOD:: tilt
-Return the tilt (roll) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
+METHOD:: roll
+Return the roll (rotation about the x-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
 
 
-METHOD:: tumble
-Return the tumble (pitch) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees).
+METHOD:: pitch
+Return the pitch (rotation about the y-axis) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees).
+
+
+METHOD: rotate
+Return the rotate (rotation about the z-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees). Equivalent to link::#-yaw::.
+
+
+METHOD: tilt
+Return the tilt (rotation about the x-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees). Equivalent to link::#-roll:.
+
+
+METHOD: tumble
+Return the tumble (rotation about the y-axis) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees). Equivalent to link::#-pitch:.
 
 
 EXAMPLES::

--- a/HelpSource/Classes/Quaternion.schelp
+++ b/HelpSource/Classes/Quaternion.schelp
@@ -73,6 +73,16 @@ METHOD:: distance
 Return the distance between two quaternions.
 
 
+METHOD:: rotate
+Return the rotation (yaw) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
+
+
+METHOD:: tilt
+Return the tilt (roll) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees).
+
+
+METHOD:: tumble
+Return the tumble (pitch) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees).
 
 
 EXAMPLES::

--- a/HelpSource/Classes/Quaternion.schelp
+++ b/HelpSource/Classes/Quaternion.schelp
@@ -85,16 +85,16 @@ METHOD:: pitch
 Return the pitch (rotation about the y-axis) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees).
 
 
-METHOD: rotate
+METHOD:: rotate
 Return the rotate (rotation about the z-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees). Equivalent to link::#-yaw::.
 
 
-METHOD: tilt
-Return the tilt (rotation about the x-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees). Equivalent to link::#-roll:.
+METHOD:: tilt
+Return the tilt (rotation about the x-axis) Euler angle in radians. Returns values between -pi and pi (-180 and 180 degrees). Equivalent to link::#-roll::.
 
 
-METHOD: tumble
-Return the tumble (rotation about the y-axis) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees). Equivalent to link::#-pitch:.
+METHOD:: tumble
+Return the tumble (rotation about the y-axis) Euler angle in radians. Returns values between -0.5pi and 0.5pi (-90 and 90 degrees). Equivalent to link::#-pitch::.
 
 
 EXAMPLES::

--- a/classes/various/Quaternion.sc
+++ b/classes/various/Quaternion.sc
@@ -113,17 +113,17 @@ Quaternion {
 
 	// roll
 	tilt {
-		^atan2((2 * (a * b - (c * d))), (1 - (2*(b.squared + c.squared))))
+		^atan2((2 * (a * b + (c * d))), (1 - (2 * (b.squared + c.squared))))
 	}
 
 	// pitch
 	tumble {
-		^asin((2 * (a * c + (b * d))).clip(-1.0, 1.0));
+		^asin((2 * (a * c - (b * d))).clip(-1.0, 1.0));
 	}
 
 	// yaw
 	rotate {
-		^atan2((2 * (a * d - (c * b))), (1 - (2*(d.squared + c.squared))))
+		^atan2((2 * (a * d + (c * b))), (1 - (2 * (d.squared + c.squared))))
 	}
 }
 

--- a/classes/various/Quaternion.sc
+++ b/classes/various/Quaternion.sc
@@ -111,19 +111,30 @@ Quaternion {
 	// conversion to euler angles
 	// Math taken from https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Quaternion_to_Euler_Angles_Conversion
 
-	// roll
-	tilt {
+
+	roll {
 		^atan2((2 * (a * b + (c * d))), (1 - (2 * (b.squared + c.squared))))
 	}
 
-	// pitch
-	tumble {
+	pitch {
 		^asin((2 * (a * c - (b * d))).clip(-1.0, 1.0));
 	}
 
-	// yaw
-	rotate {
+	yaw {
 		^atan2((2 * (a * d + (c * b))), (1 - (2 * (d.squared + c.squared))))
+	}
+
+	// for convenience with the naming convention
+	tilt {
+		^this.roll
+	}
+
+	tumble {
+		^this.pitch
+	}
+
+	rotate {
+		^this.yaw
 	}
 }
 


### PR DESCRIPTION
I realized I hadn't fully reverted the math correctly. I have tested this with Myo armband which transmits quaternion values and the math seems correct. 

I have also included these methods in the help file.

There could be a discussion about the orientation of the math with the tilt method. The ambisonic convention is that positive Y points to the left and moving clockwise around the x-axis (tilt) should put positive Y straight up. With the euler angles however, this motion results in -0.5pi radians. So this means the quaternion data (at least from the Myo) uses the convention that positive Y points to the right? And so a counterclockwise rotation around the x-axis results in the Euler angle of 0.5pi radians. I am by no means an expert with quaternions (which was my motivation to get the Euler angles in the first place).