### PR TITLE
Refactor: Matrix: *with

### DIFF
--- a/HelpSource/Classes/Matrix.schelp
+++ b/HelpSource/Classes/Matrix.schelp
@@ -28,6 +28,7 @@ cols
 
 METHOD:: with
 Create a new Matrix whose rows are filled with the given subarrays.
+
 CODE::Matrix.with([[1,2,3],[4,5,6],[7,8,9]]).postln;::
 
 ARGUMENT::

--- a/classes/various/Matrix.sc
+++ b/classes/various/Matrix.sc
@@ -10,15 +10,19 @@ Matrix[slot] : Array {
 	*newClear { arg rows=1, cols=1; // return (rows x cols) - zero matrix
 		^super.fill(rows, { Array.newClear(cols).fill(0) });
 	}
-	*with { arg array; // return matrix from 2D array (array of rows)
-		var rows;
-		if((array.flat == array.flop.flop.flat)
-		.and(array.flatten.every({arg element; element.isNumber})) ,{
+	*with { |array| // return matrix from 2D array (array of rows)
+		var shapes, shapeTest, numTest, rows;
+
+		shapes = (array.asArray).collect(_.shape).flatten;
+		shapeTest = shapes.every(_ == shapes[0]);
+		numTest = { array.flatten.every(_.isNumber) };
+
+		if((shapeTest and: numTest), {
 			rows = array.size;
-			^super.fill(rows, {arg col; array.at(col) });
-		},{
-			error("wrong type of argument in Meta_Matrix-with");this.halt
-		});
+			^super.fill(rows, { |col| array[col] })
+			}, {
+				error("wrong type of argument in Meta_Matrix-with");this.halt
+		})
 	}
 	*withFlatArray { arg rows, cols, array; // return (rows x cols) - matrix from one slot array
 		if((array.size == (rows*cols) )
@@ -620,4 +624,3 @@ Matrix[slot] : Array {
 // added inserRow, insertCol
 // getDiagonal also for nonsquare matrices
 // trace gets square restriction from getDiagonal
-


### PR DESCRIPTION
Refactor to avoid .flop.flop, which if called on Array, will expose it to a bug that could fail on large arrays.

Also, this is more efficient

Author: Michael McCrea (@mtmccrea)
