### PR TITLE
Gui fixes for ScatterView

### DIFF
--- a/HelpSource/Classes/ScatterView.schelp
+++ b/HelpSource/Classes/ScatterView.schelp
@@ -92,14 +92,10 @@ PRIVATE:: initPlot
 EXAMPLES::
 
 code::
-// you may want to use Swing or Cocoa
-SwingOSC.default.boot
-GUI.swing
-
 
 (
 var data = 1000.collect{ [1.0.rand, exprand(0.01, 1)]};
-w = GUI.window.new(bounds: Rect(40, 40, 800, 800)).front;
+w = Window.new(bounds: Rect(40, 40, 800, 800)).front;
 a = ScatterView(w, Rect(10, 10, 760, 760), data, [0,1].asSpec, [0,1].asSpec);
 a.drawAxis_(true).drawMethod_(\fillOval)
 .symbolColor_(Color.blue(0.5, 0.5)).symbolSize_(5)
@@ -108,10 +104,10 @@ a.drawAxis_(true).drawMethod_(\fillOval)
 
 (
 var numItems = 630;
-w = GUI.window.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window.new(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.isHighlight = true;
-GUI.slider.new(w, Rect(10, 120, 760, 20)).action_{|me|
+Slider.new(w, Rect(10, 120, 760, 20)).action_{|me|
 	a.highlightItemRel = me.value;
 	a.refresh;
 	// a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);
@@ -176,12 +172,13 @@ w.refresh
 // use two views stacked
 (
 var numItems = 630;
-w = SCWindow.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window.new(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 b = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/21), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.background = Color.gray(0, 0);
+b.background = Color.clear;
 a.isHighlight = true;
-SCSlider(w, Rect(10, 120, 760, 10)).action_{|me|
+Slider(w, Rect(10, 120, 760, 10)).action_{|me|
 	a.highlightItemRel = me.value;
 	w.refresh;
 	//a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);
@@ -197,10 +194,10 @@ w.refresh;
 
 (
 var numItems = 630;
-w = SCWindow.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window.new(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.isHighlight = true;
-SCRangeSlider(w, Rect(10, 120, 760, 10)).action_{|me|
+RangeSlider(w, Rect(10, 120, 760, 10)).action_{|me|
 	a.highlightRangeRel(me.lo, me.hi);
 	w.refresh;
 	// a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);

--- a/HelpSource/Classes/ScatterView2.schelp
+++ b/HelpSource/Classes/ScatterView2.schelp
@@ -64,7 +64,7 @@ code::
 // three dimensional dataset
 d = ({1.0.rand}!9000).clump(3);
 
-w = SCWindow.new("ScatterView Example");
+w = Window.new("ScatterView Example");
 v = ScatterView2(w, Rect(10, 10, 380, 380), d);
 v.selectionMode = \nextNeighbour;
 v.background = Color.black;

--- a/HelpSource/Guides/rewriteString.schelp
+++ b/HelpSource/Guides/rewriteString.schelp
@@ -276,7 +276,7 @@ SynthDef("sinegrain",
 		var env;
 		env = EnvGen.kr(Env.perc(0.01, dur, 0.2), doneAction:2);
 		Out.ar(out, SinOsc.ar(freq, 0, env))
-}).memStore;
+}).add;
 )
 
 
@@ -445,18 +445,18 @@ k.asStream.rewriteString(c, 6).all.join.postcs; // "bbbbbbab"
 (
 var w, b, u, f, z, level=0;
 
-w = SCWindow("test", Rect(40, 240, 200, 200)).front;
+w = Window("test", Rect(40, 240, 200, 200)).front;
 w.view.decorator = FlowLayout(w.bounds.copy.left_(30).top_(30));
 b = { |i| { |j|
 	var c = ({ "abcd".choose } ! 3).join;
-	SCButton(w, Rect(0,0, 30,25))
+	Button(w, Rect(0,0, 30,25))
 	.states_([[c, Color.black]])
 	.action_({ f.(c) })
 	.font_(Font(\Georgia, 11))
 } ! 4; w.view.decorator.nextLine } ! 4;
 
 w.view.decorator.nextLine;
-SCButton(w, Rect(0,0, 30,25))
+Button(w, Rect(0,0, 30,25))
 .states_({ |i| [i.asString, Color.black]} ! 16)
 .action_({ |b| level = b.value });
 
@@ -474,7 +474,7 @@ SynthDef(\p, { |out = 0, freq=400, amp=0.4, sustain=0.04|
 		SinOsc.ar(freq)
 		* XLine.ar(amp, amp * 0.001, sustain, doneAction: 2)
 	);
-}).memStore;
+}).add;
 );
 
 u = { |str|

--- a/classes/gui/ScatterView.sc
+++ b/classes/gui/ScatterView.sc
@@ -102,19 +102,16 @@ ScatterView {
 
 				GUI.pen.use{
 					// clipping into the boundingbox
-					GUI.pen.moveTo((w.bounds.left)@(w.bounds.top));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (w.bounds.width@0));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (w.bounds.width@w.bounds.height));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (0@w.bounds.height));
-					GUI.pen.lineTo((w.bounds.left)@(w.bounds.top));
+					GUI.pen.moveTo(0@0);
+					GUI.pen.lineTo(w.bounds.width@0);
+					GUI.pen.lineTo(w.bounds.width@w.bounds.height);
+					GUI.pen.lineTo(0@w.bounds.height);
+					GUI.pen.lineTo(0@0);
 					GUI.pen.clip;
 					
 					// draw Background
 					GUI.pen.color = background;
-					GUI.pen.addRect(w.bounds);
+					GUI.pen.addRect(Rect(0, 0, w.bounds.width, w.bounds.height));
 					GUI.pen.fill;
 					
 					// draw data
@@ -129,7 +126,7 @@ ScatterView {
 							);
 							GUI.pen.perform(
 								drawMethod,
-								(Rect(w.bounds.left, w.bounds.top, 0, 0) + rect)
+								rect
 							);
 						}
 					},{ // else draw lines
@@ -140,8 +137,6 @@ ScatterView {
 								((adjustedData[0][0]  * width) + (pad/2))
 								 @
 								 (((1-adjustedData[0][1]) * height) + (pad/2))
-							   	  + 
-								  (w.bounds.left@w.bounds.top)
 							);
 						};
 						// draw lines
@@ -149,9 +144,7 @@ ScatterView {
 							GUI.pen.lineTo(
 								((item[0]  * width) + (pad/2))
 								 @
-								 (((1-item[1]) * height) + (pad/2)) 
-							 	  + 
-							 	  (w.bounds.left@w.bounds.top)
+								 (((1-item[1]) * height) + (pad/2))
 							)
 						};
 						if(drawMethod == \fill, {GUI.pen.fill},{GUI.pen.stroke});
@@ -170,8 +163,7 @@ ScatterView {
 								  + 
 								  (pad/2), 
 								highlightSize.x, highlightSize.y) 
-								  + 
-								  Rect(w.bounds.left, w.bounds.top, 0, 0)),
+								  ), 
 								symbolSize,
 								highlightColor
 							);
@@ -179,33 +171,34 @@ ScatterView {
 					};
 						// draw axis
 					if (drawAxis) {
-						GUI.pen.moveTo((w.bounds.left+(pad/2))@(w.bounds.top+(pad/2)));
-						GUI.pen.lineTo((w.bounds.left+(pad/2))@(w.bounds.top+w.bounds.height-(pad/2)));
+						GUI.pen.fillColor = Color.black;
+						GUI.pen.moveTo((pad/2)@(pad/2));
+						GUI.pen.lineTo((pad/2)@(w.bounds.height-(pad/2)));
 						GUI.pen.lineTo(
-							(w.bounds.left-(pad/2)+w.bounds.width)@(w.bounds.top+w.bounds.height-(pad/2)));
+							(0-(pad/2)+w.bounds.width)@(w.bounds.height-(pad/2)));
 						specX.minval.round(0.001).asString
 							.drawAtPoint(
-								(w.bounds.left+(pad/2)+10)@
-								(w.bounds.height-(pad/2)+10));
+								((pad/2)+10)@
+								(w.bounds.height-(pad/2)));
 						xAxisName
 							.drawAtPoint(
-								(w.bounds.left+(w.bounds.width/2))@
-								(w.bounds.height-(pad/2)+10));
+								(w.bounds.width/2)@
+								(w.bounds.height-(pad/2)));
 						specX.maxval.round(0.001).asString
 							.drawAtPoint(
-								(w.bounds.left+10+w.bounds.width-20-(pad/2))@
-								(w.bounds.height-(pad/2)+10));
+								(10+w.bounds.width-20-(pad/2))@
+								(w.bounds.height-(pad/2)));
 
 
 
 						GUI.pen.rotate(-pi/2); 
 						GUI.pen.translate(w.bounds.height.neg, 0);
 						specY.minval.round(0.001).asString
-							.drawAtPoint((pad/2)@(w.bounds.left+(pad/2) -20));
+							.drawAtPoint((pad/2)@((pad/2) -20));
 						yAxisName.
-							drawAtPoint((w.bounds.height/2)@(w.bounds.left+(pad/2) -20));
+							drawAtPoint((w.bounds.height/2)@((pad/2) -20));
 						specY.maxval.round(0.001).asString
-							.drawAtPoint((w.bounds.height - (pad/2))@(w.bounds.left+(pad/2) -20));
+							.drawAtPoint((w.bounds.height - (pad/2))@((pad/2) -20));
 						GUI.pen.translate(w.bounds.height, 0);
 						GUI.pen.rotate(pi/2);
 						GUI.pen.stroke;

--- a/classes/gui/ScatterView.sc
+++ b/classes/gui/ScatterView.sc
@@ -93,7 +93,6 @@ ScatterView {
 		};
 		
 		plot = GUI.userView.new(parent, bounds)
-			.relativeOrigin_(false)
 			.drawFunc_({|w|
 				var width, height, rect, pad = 10;
 				if (drawAxis) { pad = 60 };

--- a/classes/gui/ScatterView.sc
+++ b/classes/gui/ScatterView.sc
@@ -52,17 +52,17 @@ ScatterView {
 	}
 	initPlot {
 		arg parent, bounds, data, argSpecX, argSpecY;
-		
+
 		var widthSpec, heightSpec, cross;
 		var possibleMethods;
-		
+
 		specX = argSpecX ? [0,1].asSpec;
 		specY = argSpecY ? specX.copy;
 		possibleMethods = [\fillRect, \fillOval, \strokeOval, \strokeRect];
-		
+
 		this.symbolSize = 1;
 		symbolColor = symbolColor ? Color.black;
-		
+
 		background = Color.white;
 		highlightColor = Color.red;
 		highlightItem = 0;
@@ -72,27 +72,27 @@ ScatterView {
 		drawValues = false;
 		xAxisName= "X";
 		yAxisName= "Y";
-		
+
 		this.data_(data);
-		
+
 		cross = {|rect, width, color|
 			var dx, dy, extX, extY;
 			dx = rect.left;
 			dy = rect.top;
 			extX = rect.width;
 			extY = rect.height;
-			GUI.pen.use{
-				GUI.pen.color = color;
-				GUI.pen.translate(dx, dy);
-				GUI.pen.moveTo((0)@(extY*0.5));
-				GUI.pen.lineTo(extX@(extY*0.5));
-				GUI.pen.moveTo((extX*0.5)@(0));
-				GUI.pen.lineTo((extX*0.5)@(extY));
-				GUI.pen.stroke;
+			Pen.use{
+				Pen.color = color;
+				Pen.translate(dx, dy);
+				Pen.moveTo((0)@(extY*0.5));
+				Pen.lineTo(extX@(extY*0.5));
+				Pen.moveTo((extX*0.5)@(0));
+				Pen.lineTo((extX*0.5)@(extY));
+				Pen.stroke;
 			};
 		};
-		
-		plot = GUI.userView.new(parent, bounds)
+
+		plot = UserView.new(parent, bounds)
 			.drawFunc_({|w|
 				var width, height, rect, pad = 10;
 				if (drawAxis) { pad = 60 };
@@ -100,40 +100,40 @@ ScatterView {
 				width =  w.bounds.width  - pad;
 				height = w.bounds.height - pad;
 
-				GUI.pen.use{
+				Pen.use{
 					// clipping into the boundingbox
-					GUI.pen.moveTo(0@0);
-					GUI.pen.lineTo(w.bounds.width@0);
-					GUI.pen.lineTo(w.bounds.width@w.bounds.height);
-					GUI.pen.lineTo(0@w.bounds.height);
-					GUI.pen.lineTo(0@0);
-					GUI.pen.clip;
-					
+					Pen.moveTo(0@0);
+					Pen.lineTo(w.bounds.width@0);
+					Pen.lineTo(w.bounds.width@w.bounds.height);
+					Pen.lineTo(0@w.bounds.height);
+					Pen.lineTo(0@0);
+					Pen.clip;
+
 					// draw Background
-					GUI.pen.color = background;
-					GUI.pen.addRect(Rect(0, 0, w.bounds.width, w.bounds.height));
-					GUI.pen.fill;
-					
+					Pen.color = background;
+					Pen.addRect(Rect(0, 0, w.bounds.width, w.bounds.height));
+					Pen.fill;
+
 					// draw data
-					GUI.pen.color = symbolColor;
+					Pen.color = symbolColor;
 					if (possibleMethods.includes(drawMethod), {
-						GUI.pen.beginPath;
+						Pen.beginPath;
 						adjustedData.do{|item, i|
 							rect = Rect(
 								(   item[0]  * width)  - (symbolSize.x/2) + (pad/2),
-								((1-item[1]) * height) - (symbolSize.y/2) + (pad/2), 
+								((1-item[1]) * height) - (symbolSize.y/2) + (pad/2),
 								symbolSize.x, symbolSize.y
 							);
-							GUI.pen.perform(
+							Pen.perform(
 								drawMethod,
 								rect
 							);
 						}
 					},{ // else draw lines
-						GUI.pen.width = symbolSize.x;
+						Pen.width = symbolSize.x;
 						// move to first position;
 						if (adjustedData.notNil) {
-							GUI.pen.moveTo(
+							Pen.moveTo(
 								((adjustedData[0][0]  * width) + (pad/2))
 								 @
 								 (((1-adjustedData[0][1]) * height) + (pad/2))
@@ -141,29 +141,29 @@ ScatterView {
 						};
 						// draw lines
 						adjustedData.do{|item, i|
-							GUI.pen.lineTo(
+							Pen.lineTo(
 								((item[0]  * width) + (pad/2))
 								 @
 								 (((1-item[1]) * height) + (pad/2))
 							)
 						};
-						if(drawMethod == \fill, {GUI.pen.fill},{GUI.pen.stroke});
+						if(drawMethod == \fill, {Pen.fill},{Pen.stroke});
 					});
-					
+
 					// highlight datapoint
 					if(isHighlight) {
 						highlightItem.do{|item|
 							cross.value((Rect(
-								(adjustedData[item][0]  * width) 
-								 - 
+								(adjustedData[item][0]  * width)
+								 -
 								 (highlightSize.x/2) + (pad/2),
-								((1-adjustedData[item][1]) * height) 
-								 - 
-								 (highlightSize.y/2) 
-								  + 
-								  (pad/2), 
-								highlightSize.x, highlightSize.y) 
-								  ), 
+								((1-adjustedData[item][1]) * height)
+								 -
+								 (highlightSize.y/2)
+								  +
+								  (pad/2),
+								highlightSize.x, highlightSize.y)
+								  ),
 								symbolSize,
 								highlightColor
 							);
@@ -171,10 +171,10 @@ ScatterView {
 					};
 						// draw axis
 					if (drawAxis) {
-						GUI.pen.fillColor = Color.black;
-						GUI.pen.moveTo((pad/2)@(pad/2));
-						GUI.pen.lineTo((pad/2)@(w.bounds.height-(pad/2)));
-						GUI.pen.lineTo(
+						Pen.fillColor = Color.black;
+						Pen.moveTo((pad/2)@(pad/2));
+						Pen.lineTo((pad/2)@(w.bounds.height-(pad/2)));
+						Pen.lineTo(
 							(0-(pad/2)+w.bounds.width)@(w.bounds.height-(pad/2)));
 						specX.minval.round(0.001).asString
 							.drawAtPoint(
@@ -191,17 +191,17 @@ ScatterView {
 
 
 
-						GUI.pen.rotate(-pi/2); 
-						GUI.pen.translate(w.bounds.height.neg, 0);
+						Pen.rotate(-pi/2);
+						Pen.translate(w.bounds.height.neg, 0);
 						specY.minval.round(0.001).asString
 							.drawAtPoint((pad/2)@((pad/2) -20));
 						yAxisName.
 							drawAtPoint((w.bounds.height/2)@((pad/2) -20));
 						specY.maxval.round(0.001).asString
 							.drawAtPoint((w.bounds.height - (pad/2))@((pad/2) -20));
-						GUI.pen.translate(w.bounds.height, 0);
-						GUI.pen.rotate(pi/2);
-						GUI.pen.stroke;
+						Pen.translate(w.bounds.height, 0);
+						Pen.rotate(pi/2);
+						Pen.stroke;
 					};
 						// draw values
 					if (drawValues) {
@@ -213,7 +213,7 @@ ScatterView {
 							)
 						}
 					}
-				}; // end GUI.pen.use
+				}; // end Pen.use
 			});
 	}
 	canFocus_ { arg state = false;
@@ -235,7 +235,7 @@ ScatterView3d {
 	var rotX, rotY, rotZ;
 	var specX, specY, specZ;
 	var data3d;
-	
+
 	*new {|parent, bounds, data, specX, specY, specZ, rotX = 0, rotY = 0, rotZ = 0|
 		^super.new.init3d(parent, bounds, data, specX, specY, specZ, rotX, rotY, rotZ);
 	}
@@ -260,8 +260,8 @@ ScatterView3d {
 	data_{|data|
 		data3d = data.collect {|item|
 			Matrix.withFlatArray(3, 1, [
-				specX.unmap(item[0]), 
-				specY.unmap(item[1]), 
+				specX.unmap(item[0]),
+				specY.unmap(item[1]),
 				specZ.unmap(item[2])
 			] * 2 - 1);
 		};
@@ -288,13 +288,13 @@ ScatterView3d {
 		scatterView.data = this.pr_project;
 	}
 	drawMethod_{|method|
-		scatterView.drawMethod = method;		
+		scatterView.drawMethod = method;
 	}
 	symbolSize_{|val|
-		scatterView.symbolSize = val;		
+		scatterView.symbolSize = val;
 	}
 	symbolColor_{|val|
-		scatterView.symbolColor = val;		
+		scatterView.symbolColor = val;
 	}
 	isHighlight_{|val|
 		scatterView.isHighlight_(val);
@@ -312,7 +312,7 @@ ScatterView3d {
 		scatterView.highlightSize_(size);
 	}
 	background_{|val|
-		scatterView.background = val;		
+		scatterView.background = val;
 	}
 	resize{
 		^scatterView.resize
@@ -329,13 +329,13 @@ ScatterView3d {
 		cx = cos(rotX);
 		cy = cos(rotY);
 		cz = cos(rotZ);
-			
+
 		projectionMatrix = Matrix.with([
 			[( (cy * cz) - (sx * sy * sz)), (sz.neg * cx), ((cz * sy) + (sz * sx * cy))],
 			[( (cy * sz) + (cz * sx * sy)), ( cz * cx),    ((sz * sy) - (sx * cy * cz))]
 		]);
-	
-	
+
+
 		^data3d.collect{|row|
 			(projectionMatrix * row).getCol(0)
 		};

--- a/classes/gui/ScatterView2.sc
+++ b/classes/gui/ScatterView2.sc
@@ -20,7 +20,7 @@ ScatterView2 {
 	var selectionRect;
 	var <>action;
 
-	var <>mouseDownAction, <>mouseUpAction, <>mouseMoveAction, <mouseOverAction;	
+	var <>mouseDownAction, <>mouseUpAction, <>mouseMoveAction, <mouseOverAction;
 
 	*new {|parent, bounds, data, specX, specY|
 		^super.new.initPlot(
@@ -68,7 +68,7 @@ ScatterView2 {
 		};
 	}
 	initPlot {|parent, bounds, data, argSpecX, argSpecY|
-		
+
 		specX = argSpecX ? [0,1].asSpec;
 		specY = argSpecY ? specX.copy;
 		this.data_(data);
@@ -98,59 +98,59 @@ ScatterView2 {
 
 		selected = false!numItems;
 
-		plot = GUI.userView.new(parent,bounds);
+		plot = UserView.new(parent,bounds);
 
 		plot.drawFunc = {|view|
 			var mult = view.bounds.extent.asArray;
 
 			// clipping into the boundingbox
-			GUI.pen.addRect( view.bounds.moveTo( 0, 0 ));
-			GUI.pen.clip;
+			Pen.addRect( view.bounds.moveTo( 0, 0 ));
+			Pen.clip;
 			// draw Background
-			GUI.pen.color = background;
-			GUI.pen.addRect( view.bounds.moveTo( 0, 0 ));
-			GUI.pen.fill;
+			Pen.color = background;
+			Pen.addRect( view.bounds.moveTo( 0, 0 ));
+			Pen.fill;
 
 
 			normedData.do{|pos, i|
-				GUI.pen.color = colorFunc.value(i, selected[i]);
-				GUI.pen.fillRect(((pos * mult  - (itemSize*0.5)) ++ (itemSize!2)).asRect)
+				Pen.color = colorFunc.value(i, selected[i]);
+				Pen.fillRect(((pos * mult  - (itemSize*0.5)) ++ (itemSize!2)).asRect)
 			};
 
 			// draw selection
 			selectionRect.notNil.if{
-				GUI.pen.color = Color.gray(1, 0.3);
-				GUI.pen.fillRect(selectionRect);
-				GUI.pen.color = Color.blue(0.3, 0.6);
-				GUI.pen.strokeRect(selectionRect);
+				Pen.color = Color.gray(1, 0.3);
+				Pen.fillRect(selectionRect);
+				Pen.color = Color.blue(0.3, 0.6);
+				Pen.strokeRect(selectionRect);
 			}
 		};
 		plot.mouseDownAction = {|view, x, y, modifiers, buttonNumber, clickCount|
 			var rMult, pos, normedPos, normedItemSize, threshold, index;
-	
+
 			(clickCount == 1).if{
 				pos = [x, y]-view.bounds.leftTop.asArray;
-				
+
 				rMult = view.bounds.extent.asArray.reciprocal;
 				normedPos = pos * rMult;
 				normedItemSize = itemSize * rMult;
 				normedItemSize = min(normedItemSize[0], normedItemSize[1]);
-	
+
 				this.prSelect(selectModes[selectionMode].value(
-					view, 
-					normedData, 
-					normedPos, 
+					view,
+					normedData,
+					normedPos,
 					normedItemSize,
 					selectRegion
 				));
-			};			
+			};
 			mouseDownAction.value(this, x, y, modifiers, buttonNumber, clickCount);		};
 		// draw a rect
 		plot.mouseMoveAction = {|view, x, y, modifiers|
 			var pos;
-			
+
 			pos = [x, y]-view.bounds.leftTop.asArray;
-	
+
 			selectionRect.isNil.if({
 				selected = false!numItems;
 				selectionRect = (pos++[0, 0]).asRect;
@@ -167,7 +167,7 @@ ScatterView2 {
 		};
 		plot.mouseUpAction = {|view, x, y, modifiers|
 			var mult = view.bounds.extent.asArray;
-	
+
 			selectionRect.notNil.if{
 				if(selectionRect.width<0){
 					selectionRect.left = selectionRect.left + selectionRect.width;
@@ -177,7 +177,7 @@ ScatterView2 {
 					selectionRect.top = selectionRect.top + selectionRect.height;
 					selectionRect.height = selectionRect.height.neg;
 				};
-	
+
 				selected = normedData.collect{|dat|
 					selectionRect.containsPoint((dat*mult).asPoint)
 				};

--- a/classes/gui/ScatterView2.sc
+++ b/classes/gui/ScatterView2.sc
@@ -98,7 +98,7 @@ ScatterView2 {
 
 		selected = false!numItems;
 
-		plot = GUI.userView.new(parent,bounds).relativeOrigin_(true);
+		plot = GUI.userView.new(parent,bounds);
 
 		plot.drawFunc = {|view|
 			var mult = view.bounds.extent.asArray;


### PR DESCRIPTION
This PR is similar to #30 but does not touch anything except the ScatterView and one GUI example in Guides/rewriteString.schelp.
The coordinate system is also adjusted to make up for the removal of relativeOrigin. All ScatterView examples now plot identical to the old CocoaGUI version (SC3.3.1 OSX Cocoa).
![Skärmavbild 2022-01-11 kl  18 18 34](https://user-images.githubusercontent.com/1815476/149007883-ab1be15e-90db-44f2-be73-9457525d5728.png)

(SC3.12.2 macOS Qt)
![Skärmavbild 2022-01-11 kl  18 52 49](https://user-images.githubusercontent.com/1815476/149007890-a2b48470-c5d8-4bd3-af6e-1a30dc26cb69.png)

The ```ERROR: Message 'selectIndex' not understood.``` in the ScatterView2 help example is also present in the old CocoaGUI, so for now i left it as is.