### PR TITLE
ScatterView: remove deprecations, modernize

### DIFF
--- a/HelpSource/Classes/ScatterView.schelp
+++ b/HelpSource/Classes/ScatterView.schelp
@@ -92,14 +92,9 @@ PRIVATE:: initPlot
 EXAMPLES::
 
 code::
-// you may want to use Swing or Cocoa
-SwingOSC.default.boot
-GUI.swing
-
-
 (
 var data = 1000.collect{ [1.0.rand, exprand(0.01, 1)]};
-w = GUI.window.new(bounds: Rect(40, 40, 800, 800)).front;
+w = Window(bounds: Rect(40, 40, 800, 800)).front;
 a = ScatterView(w, Rect(10, 10, 760, 760), data, [0,1].asSpec, [0,1].asSpec);
 a.drawAxis_(true).drawMethod_(\fillOval)
 .symbolColor_(Color.blue(0.5, 0.5)).symbolSize_(5)
@@ -108,10 +103,10 @@ a.drawAxis_(true).drawMethod_(\fillOval)
 
 (
 var numItems = 630;
-w = GUI.window.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.isHighlight = true;
-GUI.slider.new(w, Rect(10, 120, 760, 20)).action_{|me|
+Slider.new(w, Rect(10, 120, 760, 20)).action_{|me|
 	a.highlightItemRel = me.value;
 	a.refresh;
 	// a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);
@@ -176,12 +171,12 @@ w.refresh
 // use two views stacked
 (
 var numItems = 630;
-w = SCWindow.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 b = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/21), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.background = Color.gray(0, 0);
 a.isHighlight = true;
-SCSlider(w, Rect(10, 120, 760, 10)).action_{|me|
+Slider(w, Rect(10, 120, 760, 10)).action_{|me|
 	a.highlightItemRel = me.value;
 	w.refresh;
 	//a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);
@@ -197,10 +192,10 @@ w.refresh;
 
 (
 var numItems = 630;
-w = SCWindow.new(bounds: Rect(40, 40, 800, 150)).front;
+w = Window(bounds: Rect(40, 40, 800, 150)).front;
 a = ScatterView(w, Rect(10, 10, 760, 100), {|i| [sin(i/50), sin(0.05*i)]}!numItems, [-1,1].asSpec, [-1,1].asSpec);
 a.isHighlight = true;
-SCRangeSlider(w, Rect(10, 120, 760, 10)).action_{|me|
+RangeSlider(w, Rect(10, 120, 760, 10)).action_{|me|
 	a.highlightRangeRel(me.lo, me.hi);
 	w.refresh;
 	// a.highlightItem = (me.value*numItems).asInteger.min(numItems-1);

--- a/HelpSource/Classes/ScatterView2.schelp
+++ b/HelpSource/Classes/ScatterView2.schelp
@@ -64,7 +64,7 @@ code::
 // three dimensional dataset
 d = ({1.0.rand}!9000).clump(3);
 
-w = SCWindow.new("ScatterView Example");
+w = Window("ScatterView Example");
 v = ScatterView2(w, Rect(10, 10, 380, 380), d);
 v.selectionMode = \nextNeighbour;
 v.background = Color.black;

--- a/HelpSource/Classes/ScatterView3d.schelp
+++ b/HelpSource/Classes/ScatterView3d.schelp
@@ -158,7 +158,7 @@ code::
 (
 var data;
 data = {{2.0.rand2}!3}!150;
-w = Window.new("3D Scatterplot", Rect(40,40, 500, 500)).front;
+w = Window("3D Scatterplot", Rect(40,40, 500, 500)).front;
 a = ScatterView3d(w, Rect(10,10, 450, 450), data, [-2, 2].asSpec);
 a.drawMethod = \fillRect;
 a.symbolSize = 3;

--- a/classes/gui/ScatterView.sc
+++ b/classes/gui/ScatterView.sc
@@ -15,6 +15,9 @@ ScatterView {
 	}
 	background_ {|color|
 		background = color;
+		plot !? {
+			plot.background = color;
+		}
 	}
 	highlightItem_{|item|
 		highlightItem = item.isKindOf(Collection).if({item}, {[item]});
@@ -52,17 +55,17 @@ ScatterView {
 	}
 	initPlot {
 		arg parent, bounds, data, argSpecX, argSpecY;
-		
+
 		var widthSpec, heightSpec, cross;
 		var possibleMethods;
-		
+
 		specX = argSpecX ? [0,1].asSpec;
 		specY = argSpecY ? specX.copy;
 		possibleMethods = [\fillRect, \fillOval, \strokeOval, \strokeRect];
-		
+
 		this.symbolSize = 1;
 		symbolColor = symbolColor ? Color.black;
-		
+
 		background = Color.white;
 		highlightColor = Color.red;
 		highlightItem = 0;
@@ -72,157 +75,136 @@ ScatterView {
 		drawValues = false;
 		xAxisName= "X";
 		yAxisName= "Y";
-		
+
 		this.data_(data);
-		
+
 		cross = {|rect, width, color|
 			var dx, dy, extX, extY;
 			dx = rect.left;
 			dy = rect.top;
 			extX = rect.width;
 			extY = rect.height;
-			GUI.pen.use{
-				GUI.pen.color = color;
-				GUI.pen.translate(dx, dy);
-				GUI.pen.moveTo((0)@(extY*0.5));
-				GUI.pen.lineTo(extX@(extY*0.5));
-				GUI.pen.moveTo((extX*0.5)@(0));
-				GUI.pen.lineTo((extX*0.5)@(extY));
-				GUI.pen.stroke;
-			};
+			Pen.color = color;
+			Pen.translate(dx, dy);
+			Pen.moveTo((0)@(extY*0.5));
+			Pen.lineTo(extX@(extY*0.5));
+			Pen.moveTo((extX*0.5)@(0));
+			Pen.lineTo((extX*0.5)@(extY));
+			Pen.stroke;
 		};
-		
-		plot = GUI.userView.new(parent, bounds)
-			.relativeOrigin_(false)
-			.drawFunc_({|w|
-				var width, height, rect, pad = 10;
-				if (drawAxis) { pad = 60 };
 
-				width =  w.bounds.width  - pad;
-				height = w.bounds.height - pad;
+		plot = UserView.new(parent, bounds)
+		.background_(background)
+		.drawFunc_({|w|
+			var width, height, rect, pad = 10;
+			if (drawAxis) { pad = 60 };
 
-				GUI.pen.use{
-					// clipping into the boundingbox
-					GUI.pen.moveTo((w.bounds.left)@(w.bounds.top));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (w.bounds.width@0));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (w.bounds.width@w.bounds.height));
-					GUI.pen.lineTo(((w.bounds.left)@(w.bounds.top)) 
-							+ (0@w.bounds.height));
-					GUI.pen.lineTo((w.bounds.left)@(w.bounds.top));
-					GUI.pen.clip;
-					
-					// draw Background
-					GUI.pen.color = background;
-					GUI.pen.addRect(w.bounds);
-					GUI.pen.fill;
-					
-					// draw data
-					GUI.pen.color = symbolColor;
-					if (possibleMethods.includes(drawMethod), {
-						GUI.pen.beginPath;
-						adjustedData.do{|item, i|
-							rect = Rect(
-								(   item[0]  * width)  - (symbolSize.x/2) + (pad/2),
-								((1-item[1]) * height) - (symbolSize.y/2) + (pad/2), 
-								symbolSize.x, symbolSize.y
-							);
-							GUI.pen.perform(
-								drawMethod,
-								(Rect(w.bounds.left, w.bounds.top, 0, 0) + rect)
-							);
-						}
-					},{ // else draw lines
-						GUI.pen.width = symbolSize.x;
-						// move to first position;
-						if (adjustedData.notNil) {
-							GUI.pen.moveTo(
-								((adjustedData[0][0]  * width) + (pad/2))
-								 @
-								 (((1-adjustedData[0][1]) * height) + (pad/2))
-							   	  + 
-								  (w.bounds.left@w.bounds.top)
-							);
-						};
-						// draw lines
-						adjustedData.do{|item, i|
-							GUI.pen.lineTo(
-								((item[0]  * width) + (pad/2))
-								 @
-								 (((1-item[1]) * height) + (pad/2)) 
-							 	  + 
-							 	  (w.bounds.left@w.bounds.top)
-							)
-						};
-						if(drawMethod == \fill, {GUI.pen.fill},{GUI.pen.stroke});
-					});
-					
-					// highlight datapoint
-					if(isHighlight) {
-						highlightItem.do{|item|
-							cross.value((Rect(
-								(adjustedData[item][0]  * width) 
-								 - 
-								 (highlightSize.x/2) + (pad/2),
-								((1-adjustedData[item][1]) * height) 
-								 - 
-								 (highlightSize.y/2) 
-								  + 
-								  (pad/2), 
-								highlightSize.x, highlightSize.y) 
-								  + 
-								  Rect(w.bounds.left, w.bounds.top, 0, 0)),
-								symbolSize,
-								highlightColor
-							);
-						}; // od
-					};
-						// draw axis
-					if (drawAxis) {
-						GUI.pen.moveTo((w.bounds.left+(pad/2))@(w.bounds.top+(pad/2)));
-						GUI.pen.lineTo((w.bounds.left+(pad/2))@(w.bounds.top+w.bounds.height-(pad/2)));
-						GUI.pen.lineTo(
-							(w.bounds.left-(pad/2)+w.bounds.width)@(w.bounds.top+w.bounds.height-(pad/2)));
-						specX.minval.round(0.001).asString
-							.drawAtPoint(
-								(w.bounds.left+(pad/2)+10)@
-								(w.bounds.height-(pad/2)+10));
-						xAxisName
-							.drawAtPoint(
-								(w.bounds.left+(w.bounds.width/2))@
-								(w.bounds.height-(pad/2)+10));
-						specX.maxval.round(0.001).asString
-							.drawAtPoint(
-								(w.bounds.left+10+w.bounds.width-20-(pad/2))@
-								(w.bounds.height-(pad/2)+10));
+			width =  w.bounds.width  - pad;
+			height = w.bounds.height - pad;
 
+			// clipping into the boundingbox
+			Pen.addRect(Rect(0,0,w.bounds.width, w.bounds.height));
+			Pen.clip;
 
-
-						GUI.pen.rotate(-pi/2); 
-						GUI.pen.translate(w.bounds.height.neg, 0);
-						specY.minval.round(0.001).asString
-							.drawAtPoint((pad/2)@(w.bounds.left+(pad/2) -20));
-						yAxisName.
-							drawAtPoint((w.bounds.height/2)@(w.bounds.left+(pad/2) -20));
-						specY.maxval.round(0.001).asString
-							.drawAtPoint((w.bounds.height - (pad/2))@(w.bounds.left+(pad/2) -20));
-						GUI.pen.translate(w.bounds.height, 0);
-						GUI.pen.rotate(pi/2);
-						GUI.pen.stroke;
-					};
-						// draw values
-					if (drawValues) {
-						adjustedData.do{|item, i|
-							data.at(i).round(0.001).asString.drawAtPoint(
-								((item[0]  * width) + (pad/2))
-								@
-								(((1-item[1]) * height) + (pad/2) + 10)
-							)
-						}
-					}
-				}; // end GUI.pen.use
+			// draw data
+			Pen.color = symbolColor;
+			if (possibleMethods.includes(drawMethod), {
+				Pen.beginPath;
+				adjustedData.do{|item, i|
+					rect = Rect(
+						(   item[0]  * width)  - (symbolSize.x/2) + (pad/2),
+						((1-item[1]) * height) - (symbolSize.y/2) + (pad/2),
+						symbolSize.x, symbolSize.y
+					);
+					Pen.perform(
+						drawMethod,
+						rect
+					);
+				}
+			},{ // else draw lines
+				Pen.width = symbolSize.x;
+				// move to first position;
+				if (adjustedData.notNil) {
+					Pen.moveTo(
+						((adjustedData[0][0]  * width) + (pad/2))
+						@
+						(((1-adjustedData[0][1]) * height) + (pad/2))
+					);
+				};
+				// draw lines
+				adjustedData.do{|item, i|
+					Pen.lineTo(
+						((item[0]  * width) + (pad/2))
+						@
+						(((1-item[1]) * height) + (pad/2))
+					)
+				};
+				if(drawMethod == \fill, {Pen.fill},{Pen.stroke});
 			});
+
+			// highlight datapoint
+			if(isHighlight) {
+				highlightItem.do{|item|
+					cross.value(Rect(
+						(adjustedData[item][0]  * width)
+						-
+						(highlightSize.x/2) + (pad/2),
+						((1-adjustedData[item][1]) * height)
+						-
+						(highlightSize.y/2)
+						+
+						(pad/2),
+						highlightSize.x, highlightSize.y),
+					symbolSize,
+					highlightColor
+					);
+				}; // od
+			};
+			// draw axis
+			if (drawAxis) {
+				Pen.moveTo((pad/2)@(pad/2));
+				Pen.lineTo((pad/2)@(w.bounds.height-(pad/2)));
+				Pen.lineTo(
+					(w.bounds.width-(pad/2))@(w.bounds.height-(pad/2))
+				);
+				specX.minval.round(0.001).asString
+				.drawAtPoint(
+					((pad/2)+10)@
+					(w.bounds.height-(pad/2)+10));
+				xAxisName
+				.drawAtPoint(
+					((w.bounds.width/2))@
+					(w.bounds.height-(pad/2)+10));
+				specX.maxval.round(0.001).asString
+				.drawAtPoint(
+					(10+w.bounds.width-20-(pad/2))@
+					(w.bounds.height-(pad/2)+10));
+
+
+
+				Pen.rotate(-pi/2);
+				Pen.translate(w.bounds.height.neg, 0);
+				specY.minval.round(0.001).asString
+				.drawAtPoint((pad/2)@((pad/2) -20));
+				yAxisName.
+				drawAtPoint((w.bounds.height/2)@((pad/2) -20));
+				specY.maxval.round(0.001).asString
+				.drawAtPoint((w.bounds.height - (pad/2))@((pad/2) -20));
+				Pen.translate(w.bounds.height, 0);
+				Pen.rotate(pi/2);
+				Pen.stroke;
+			};
+			// draw values
+			if (drawValues) {
+				adjustedData.do{|item, i|
+					data.at(i).round(0.001).asString.drawAtPoint(
+						((item[0]  * width) + (pad/2))
+						@
+						(((1-item[1]) * height) + (pad/2) + 10)
+					)
+				}
+			}
+		});
 	}
 	canFocus_ { arg state = false;
 		plot.canFocus_(state);
@@ -236,6 +218,7 @@ ScatterView {
 	visible {
 		^plot.visible
 	}
+
 }
 
 ScatterView3d {
@@ -243,7 +226,7 @@ ScatterView3d {
 	var rotX, rotY, rotZ;
 	var specX, specY, specZ;
 	var data3d;
-	
+
 	*new {|parent, bounds, data, specX, specY, specZ, rotX = 0, rotY = 0, rotZ = 0|
 		^super.new.init3d(parent, bounds, data, specX, specY, specZ, rotX, rotY, rotZ);
 	}
@@ -268,14 +251,14 @@ ScatterView3d {
 	data_{|data|
 		data3d = data.collect {|item|
 			Matrix.withFlatArray(3, 1, [
-				specX.unmap(item[0]), 
-				specY.unmap(item[1]), 
+				specX.unmap(item[0]),
+				specY.unmap(item[1]),
 				specZ.unmap(item[2])
 			] * 2 - 1);
 		};
 		scatterView.data = this.pr_project;
 
-//		highlightItem = min(highlightItem, (adjustedData.size-1));
+		//		highlightItem = min(highlightItem, (adjustedData.size-1));
 	}
 	refresh {
 		scatterView.refresh;
@@ -296,13 +279,13 @@ ScatterView3d {
 		scatterView.data = this.pr_project;
 	}
 	drawMethod_{|method|
-		scatterView.drawMethod = method;		
+		scatterView.drawMethod = method;
 	}
 	symbolSize_{|val|
-		scatterView.symbolSize = val;		
+		scatterView.symbolSize = val;
 	}
 	symbolColor_{|val|
-		scatterView.symbolColor = val;		
+		scatterView.symbolColor = val;
 	}
 	isHighlight_{|val|
 		scatterView.isHighlight_(val);
@@ -320,7 +303,7 @@ ScatterView3d {
 		scatterView.highlightSize_(size);
 	}
 	background_{|val|
-		scatterView.background = val;		
+		scatterView.background = val;
 	}
 	resize{
 		^scatterView.resize
@@ -337,13 +320,13 @@ ScatterView3d {
 		cx = cos(rotX);
 		cy = cos(rotY);
 		cz = cos(rotZ);
-			
+
 		projectionMatrix = Matrix.with([
 			[( (cy * cz) - (sx * sy * sz)), (sz.neg * cx), ((cz * sy) + (sz * sx * cy))],
 			[( (cy * sz) + (cz * sx * sy)), ( cz * cx),    ((sz * sy) - (sx * cy * cz))]
 		]);
-	
-	
+
+
 		^data3d.collect{|row|
 			(projectionMatrix * row).getCol(0)
 		};

--- a/classes/gui/ScatterView2.sc
+++ b/classes/gui/ScatterView2.sc
@@ -20,7 +20,7 @@ ScatterView2 {
 	var selectionRect;
 	var <>action;
 
-	var <>mouseDownAction, <>mouseUpAction, <>mouseMoveAction, <mouseOverAction;	
+	var <>mouseDownAction, <>mouseUpAction, <>mouseMoveAction, <mouseOverAction;
 
 	*new {|parent, bounds, data, specX, specY|
 		^super.new.initPlot(
@@ -68,7 +68,7 @@ ScatterView2 {
 		};
 	}
 	initPlot {|parent, bounds, data, argSpecX, argSpecY|
-		
+
 		specX = argSpecX ? [0,1].asSpec;
 		specY = argSpecY ? specX.copy;
 		this.data_(data);
@@ -98,59 +98,59 @@ ScatterView2 {
 
 		selected = false!numItems;
 
-		plot = GUI.userView.new(parent,bounds).relativeOrigin_(true);
+		plot = UserView.new(parent,bounds);
 
 		plot.drawFunc = {|view|
 			var mult = view.bounds.extent.asArray;
 
 			// clipping into the boundingbox
-			GUI.pen.addRect( view.bounds.moveTo( 0, 0 ));
-			GUI.pen.clip;
+			Pen.addRect( view.bounds.moveTo( 0, 0 ));
+			Pen.clip;
 			// draw Background
-			GUI.pen.color = background;
-			GUI.pen.addRect( view.bounds.moveTo( 0, 0 ));
-			GUI.pen.fill;
+			Pen.color = background;
+			Pen.addRect( view.bounds.moveTo( 0, 0 ));
+			Pen.fill;
 
 
 			normedData.do{|pos, i|
-				GUI.pen.color = colorFunc.value(i, selected[i]);
-				GUI.pen.fillRect(((pos * mult  - (itemSize*0.5)) ++ (itemSize!2)).asRect)
+				Pen.color = colorFunc.value(i, selected[i]);
+				Pen.fillRect(((pos * mult  - (itemSize*0.5)) ++ (itemSize!2)).asRect)
 			};
 
 			// draw selection
 			selectionRect.notNil.if{
-				GUI.pen.color = Color.gray(1, 0.3);
-				GUI.pen.fillRect(selectionRect);
-				GUI.pen.color = Color.blue(0.3, 0.6);
-				GUI.pen.strokeRect(selectionRect);
+				Pen.color = Color.gray(1, 0.3);
+				Pen.fillRect(selectionRect);
+				Pen.color = Color.blue(0.3, 0.6);
+				Pen.strokeRect(selectionRect);
 			}
 		};
 		plot.mouseDownAction = {|view, x, y, modifiers, buttonNumber, clickCount|
 			var rMult, pos, normedPos, normedItemSize, threshold, index;
-	
+
 			(clickCount == 1).if{
 				pos = [x, y]-view.bounds.leftTop.asArray;
-				
+
 				rMult = view.bounds.extent.asArray.reciprocal;
 				normedPos = pos * rMult;
 				normedItemSize = itemSize * rMult;
 				normedItemSize = min(normedItemSize[0], normedItemSize[1]);
-	
+
 				this.prSelect(selectModes[selectionMode].value(
-					view, 
-					normedData, 
-					normedPos, 
+					view,
+					normedData,
+					normedPos,
 					normedItemSize,
 					selectRegion
 				));
-			};			
+			};
 			mouseDownAction.value(this, x, y, modifiers, buttonNumber, clickCount);		};
 		// draw a rect
 		plot.mouseMoveAction = {|view, x, y, modifiers|
 			var pos;
-			
+
 			pos = [x, y]-view.bounds.leftTop.asArray;
-	
+
 			selectionRect.isNil.if({
 				selected = false!numItems;
 				selectionRect = (pos++[0, 0]).asRect;
@@ -167,7 +167,7 @@ ScatterView2 {
 		};
 		plot.mouseUpAction = {|view, x, y, modifiers|
 			var mult = view.bounds.extent.asArray;
-	
+
 			selectionRect.notNil.if{
 				if(selectionRect.width<0){
 					selectionRect.left = selectionRect.left + selectionRect.width;
@@ -177,7 +177,7 @@ ScatterView2 {
 					selectionRect.top = selectionRect.top + selectionRect.height;
 					selectionRect.height = selectionRect.height.neg;
 				};
-	
+
 				selected = normedData.collect{|dat|
 					selectionRect.containsPoint((dat*mult).asPoint)
 				};


### PR DESCRIPTION
Removing deprecated calls for the ScatterView:
- `relativeOrigin` from wslib
- calls to `GUI`

see also https://scsynth.org/t/problems-with-scatterview/5701