### PR TITLE
Matrix: remove limitation to numerical entries

### DIFF
--- a/classes/various/Matrix.sc
+++ b/classes/various/Matrix.sc
@@ -504,20 +504,22 @@ Matrix[slot] : Array {
 	adjoint { // return the adjoint of the matrix
 		var adjoint;
 		adjoint = Matrix.newClear(this.rows, this.cols);
-		this.rows.do({ arg i;
-			this.cols.do({ arg j;
-				adjoint.put(i,j,this.cofactor(i,j));
-			});
-		});
-		^adjoint.flop;
+		this.rows.do { arg i;
+			this.cols.do { arg j;
+				adjoint.put(i, j, this.cofactor(i, j))
+			}
+		};
+		^adjoint.flop
 	}
 	inverse { // return the inverse matrix
-		if(this.det != 0.0,{
-			^(this.adjoint / (this.det) );
-		},{error("matrix singular in Matrix-inverse");this.halt;});
+		var det = this.det;
+		if(this.det == 0) {
+			Error("matrix singular in Matrix-inverse").throw
+		};
+		^this.adjoint / this.det
 	}
 	gram { // the gram matrix
-		^(this.flop * this);
+		^this.flop * this
 	}
 	grammian { // the grammian of a matrix
 		^(this.gram.det);

--- a/classes/various/Matrix.sc
+++ b/classes/various/Matrix.sc
@@ -438,8 +438,8 @@ Matrix[slot] : Array {
 		^if(summand2.isNumber) {
 			this.addNumber(summand2)
 		} {
-			if(this.shape == summand2.shape) {
-				Error("The shape of receiver must be the same as that of the operand").throw
+			if(this.shape != summand2.shape) {
+				Error("Operand shapes do not match: % and %".format(this.shape, summand2.shape)).throw
 			};
 			result = Matrix.newClear(this.rows, this.cols);
 			this.rows.do { arg i;
@@ -460,8 +460,8 @@ Matrix[slot] : Array {
 		^if (summand2.isNumber) {
 			this.subNumber(summand2)
 		} {
-			if(this.shape == summand2.shape) {
-				Error("The shape of receiver must be the same as that of the operand").throw
+			if(this.shape != summand2.shape) {
+				Error("Operand shapes do not match: % and %".format(this.shape, summand2.shape)).throw
 			};
 			result = Matrix.newClear(this.rows, this.cols);
 			this.rows.do { arg i;


### PR DESCRIPTION
This is experimental and will need careful checking.

For prior discussion see: #38 

There are also improvements to error handling in the `Matrix` class.

I am not the expert user for matrices, so it would be good if others could write up tests.
We can put them into unit tests once we have collected them.

Here is some code that makes testing easy:

```supercollider


(
~runOnServer = { |func, callback, value = 1.2|
	var shape;
	{ 
		var result = func.(DC.ar(value));
		shape = result.shape;
		if(shape.isNil) { result } { result.flat }
	}.loadToFloatArray(0.001, action: { |array|
		if(shape.isNil) {
			callback.value(array.first)
		} {
			callback.value(array.keep(shape.asArray.product).reshape(*shape))
		}
	});
};
~compareResults = { |func, callback, value|
	var sclangResult = func.value(value);
	~runOnServer.(func, { |scsynthResult| callback.value(scsynthResult, sclangResult) }, value)
	
};
~sameValue = { |func, callback, value|
	~compareResults.(func, { |scsynthResult, sclangResult|
		var same;
		scsynthResult = scsynthResult.round(0.001);
		sclangResult = sclangResult.round(0.001);
		scsynthResult.postln;
		sclangResult.postln;
		same = scsynthResult == sclangResult;
		"The results are %the same.".format(if(same.not) { "not " } { "" }).postln;
		callback.(same)
	}, value);
	
};
~sameMatrixValue = { |func, callback, value|
	~compareResults.(func, { |scsynthResult, sclangResult|
		var same;
		scsynthResult = Matrix.with(scsynthResult).round(0.001);
		sclangResult = sclangResult.round(0.001);
		scsynthResult.postln;
		sclangResult.postln;
		same = scsynthResult == sclangResult;
		"The results are %the same.".format(if(same.not) { "not " } { "" }).postln;
		callback.(same)
	}, value);
	
};
)

(
~sameMatrixValue.({ |value|
	var a, b;
	a = Matrix.fill(4, 5, { value });
	b = Matrix.fill(5, 4, { value });
	a.mulMatrix(b)
}, value: 1.2)
)


(
~sameMatrixValue.({ |value|
	var a, b;
	a = Matrix.fill(4, 4, { value });
	b = 10;
	a * b
}, value: 1.2)
)



(
~sameMatrixValue.({ |value|
	var a, b;
	a = Matrix.fill(4, 4, { value });
	b = Matrix.fill(4, 4, { value });
	a + b
}, value: 1.2)
)

(
~sameMatrixValue.({ |value|
	var a, b;
	a = Matrix.fill(4, 4, { value });
	b = Matrix.fill(4, 4, { value });
	a - b
}, value: 1.2)
)


(
~sameMatrixValue.({ |value|
	var a, b;
	a = Matrix.fill(4, 4, { value });
	b = Matrix.fill(4, 4, { value });
	a mul: b
}, value: 1.2)
)

(
~sameMatrixValue.({ |value|
	var a;
	a = Matrix.fill(4, 4, { value });
	a.adjoint
}, value: 1.2)
)

(
~sameValue.({ |value|
	var a;
	a = Matrix.fill(4, 4, { value });
	a.det
}, value: 1.2)
)


(
~sameValue.({ |value|
	var a;
	a = Matrix.fill(4, 4, { value });
	a.cofactor(1, 1)
}, value: 1.2)
)



```